### PR TITLE
Remove duplicate settings

### DIFF
--- a/src/Controls/settings-options.js
+++ b/src/Controls/settings-options.js
@@ -929,8 +929,6 @@ export const settings_general = {
   truck: {
     numeric: [
       turnPenalityCost,
-      countryCrossingPenality,
-      countryCrossingCost,
       useHighways,
       useTollways,
       tollBoothCost,
@@ -955,8 +953,6 @@ export const settings_general = {
   car: {
     numeric: [
       turnPenalityCost,
-      countryCrossingPenality,
-      countryCrossingCost,
       useHighways,
       useTollways,
       tollBoothCost,
@@ -978,8 +974,6 @@ export const settings_general = {
   bus: {
     numeric: [
       turnPenalityCost,
-      countryCrossingPenality,
-      countryCrossingCost,
       useHighways,
       useLivingStreets,
       useTollways,
@@ -1020,8 +1014,6 @@ export const settings_general = {
     numeric: [
       useFerry,
       useLivingStreets,
-      countryCrossingCost,
-      countryCrossingPenality,
       turnPenalityCost,
       servicePenalty,
       serviceFactor,
@@ -1032,8 +1024,6 @@ export const settings_general = {
   motorcycle: {
     numeric: [
       turnPenalityCost,
-      countryCrossingPenality,
-      countryCrossingCost,
       useHighways,
       useTrails,
       useTollways,

--- a/src/Controls/settings-options.js
+++ b/src/Controls/settings-options.js
@@ -58,8 +58,8 @@ const axleLoad = {
   },
 }
 
-const countryCrossingPenality = {
-  name: 'Border penalty',
+const countryCrossingPenalty = {
+  name: 'Border Penalty',
   param: 'country_crossing_penalty',
   description:
     'A penalty applied for a country crossing. This penalty can be used to create paths that avoid spanning country boundaries. The default penalty is 0.',
@@ -72,7 +72,7 @@ const countryCrossingPenality = {
 }
 
 const countryCrossingCost = {
-  name: 'Border cost',
+  name: 'Border Cost',
   param: 'country_crossing_cost',
   description:
     'A cost applied when encountering an international border. This cost is added to the estimated and elapsed times. The default cost is 600 seconds.',
@@ -84,8 +84,8 @@ const countryCrossingCost = {
   },
 }
 
-const turnPenalityCost = {
-  name: 'Turn penalty',
+const turnPenaltyCost = {
+  name: 'Turn Penalty',
   param: 'maneuver_penalty',
   description:
     'A penalty applied when transitioning between roads that do not have consistent naming–in other words, no road names in common. This penalty can be used to create simpler routes that tend to have fewer maneuvers or narrative guidance instructions. The default maneuver penalty is five seconds.',
@@ -797,7 +797,7 @@ export const profile_settings = {
       servicePenalty,
       serviceFactor,
       countryCrossingCost,
-      countryCrossingPenality,
+      countryCrossingPenalty,
       useTruckRoutes,
     ],
     boolean: [hazardousMaterials, shortest, ignoreHierarchies],
@@ -817,7 +817,7 @@ export const profile_settings = {
       gateCost,
       gatePenalty,
       countryCrossingCost,
-      countryCrossingPenality,
+      countryCrossingPenalty,
     ],
     boolean: [
       shortest,
@@ -844,7 +844,7 @@ export const profile_settings = {
       servicePenalty,
       serviceFactor,
       countryCrossingCost,
-      countryCrossingPenality,
+      countryCrossingPenalty,
     ],
     boolean: [
       shortest,
@@ -880,7 +880,7 @@ export const profile_settings = {
       gateCost,
       gatePenalty,
       countryCrossingCost,
-      countryCrossingPenality,
+      countryCrossingPenalty,
     ],
     boolean: [shortest, ignoreHierarchies],
     enum: [],
@@ -912,7 +912,7 @@ export const profile_settings = {
       gateCost,
       gatePenalty,
       countryCrossingCost,
-      countryCrossingPenality,
+      countryCrossingPenalty,
     ],
     boolean: [
       shortest,
@@ -928,7 +928,7 @@ export const profile_settings = {
 export const settings_general = {
   truck: {
     numeric: [
-      turnPenalityCost,
+      turnPenaltyCost,
       useHighways,
       useTollways,
       tollBoothCost,
@@ -952,7 +952,7 @@ export const settings_general = {
   },
   car: {
     numeric: [
-      turnPenalityCost,
+      turnPenaltyCost,
       useHighways,
       useTollways,
       tollBoothCost,
@@ -973,7 +973,7 @@ export const settings_general = {
   },
   bus: {
     numeric: [
-      turnPenalityCost,
+      turnPenaltyCost,
       useHighways,
       useLivingStreets,
       useTollways,
@@ -1014,7 +1014,7 @@ export const settings_general = {
     numeric: [
       useFerry,
       useLivingStreets,
-      turnPenalityCost,
+      turnPenaltyCost,
       servicePenalty,
       serviceFactor,
     ],
@@ -1023,7 +1023,7 @@ export const settings_general = {
   },
   motorcycle: {
     numeric: [
-      turnPenalityCost,
+      turnPenaltyCost,
       useHighways,
       useTrails,
       useTollways,


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

<!-- Remove this section if not applicable -->

Closes #235

## 👨‍💻 Changes proposed

- Removed the "Border Cost" and "Border Penalty" settings from duplication in "General Settings", so that they only live in "Extra Settings" now. If "General Settings" is a better place for them to live, I'll be happy to move them there instead.
- Corrected some inconsistent capitalisation and spelling mistakes ("penality" 🤪)

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots

<!-- Add any relevant screenshots if applicable -->
