### PR TITLE
Fix Valhalla/Nominatim race condition

### DIFF
--- a/src/Controls/index.jsx
+++ b/src/Controls/index.jsx
@@ -95,7 +95,6 @@ class MainControl extends React.Component {
         const payload = {
           latLng,
           fromPerma: true,
-          permaLast: i === coordinates.length / 2 - 1,
           index: i,
         }
         processedCoords.push([latLng.lat, latLng.lng])

--- a/src/Controls/index.jsx
+++ b/src/Controls/index.jsx
@@ -94,7 +94,6 @@ class MainControl extends React.Component {
         const latLng = { lat: next, lng: current }
         const payload = {
           latLng,
-          fromPerma: true,
           index: i,
         }
         processedCoords.push([latLng.lat, latLng.lng])

--- a/src/actions/directionsActions.js
+++ b/src/actions/directionsActions.js
@@ -158,24 +158,15 @@ export const fetchReverseGeocodePerma = (object) => (dispatch) => {
   dispatch(requestGeocodeResults({ index: object.index, reverse: true }))
 
   const { index } = object
-  const { permaLast } = object
   const { lng, lat } = object.latLng
 
   if (index > 1) {
-    dispatch(doAddWaypoint(true, permaLast))
+    dispatch(doAddWaypoint(true))
   }
 
   reverse_geocode(lng, lat)
     .then((response) => {
-      dispatch(
-        processGeocodeResponse(
-          response.data,
-          index,
-          true,
-          [lng, lat],
-          permaLast
-        )
-      )
+      dispatch(processGeocodeResponse(response.data, index, true, [lng, lat]))
     })
     .catch((error) => {
       console.log(error) //eslint-disable-line
@@ -248,7 +239,7 @@ export const fetchGeocode = (object) => (dispatch) => {
 }
 
 const processGeocodeResponse =
-  (data, index, reverse, lngLat, permaLast) => (dispatch) => {
+  (data, index, reverse, lngLat) => (dispatch, getState) => {
     const addresses = parseGeocodeResponse(data, lngLat)
     // if no address can be found
     if (addresses.length === 0) {
@@ -271,10 +262,9 @@ const processGeocodeResponse =
           addressindex: 0,
         })
       )
-      if (permaLast === undefined) {
-        dispatch(makeRequest())
-        dispatch(updatePermalink())
-      } else if (permaLast) {
+
+      const { pendingGeocodes } = getState().directions
+      if (pendingGeocodes === 0) {
         dispatch(makeRequest())
         dispatch(updatePermalink())
       }

--- a/src/reducers/directions.js
+++ b/src/reducers/directions.js
@@ -31,6 +31,7 @@ const initialState = {
     timeNow: -1,
   },
   selectedAddresses: '',
+  pendingGeocodes: 0,
   results: {
     [VALHALLA_OSM_URL]: {
       data: {},
@@ -117,6 +118,7 @@ export const directions = (state = initialState, action) => {
               }
             : waypoint
         ),
+        pendingGeocodes: state.pendingGeocodes - 1,
       }
 
     case REQUEST_GEOCODE_RESULTS:
@@ -127,6 +129,7 @@ export const directions = (state = initialState, action) => {
             ? { ...waypoint, isFetching: true }
             : waypoint
         ),
+        pendingGeocodes: state.pendingGeocodes + 1,
       }
 
     case UPDATE_TEXTINPUT:


### PR DESCRIPTION
## 🛠️ Fixes Issue

(Partially?) closes #227 

## 👨‍💻 Changes proposed

As seen in the issue above, there are sometimes cases when pasting a route URL results in some of the waypoints not being included in the route (though they are still present on the map). See below screenshots for example.

I managed to track this down to a race condition where the retrieval of the route directions from the Valhalla API would execute before all the waypoints' geocode results would be returned from the Nominatim API. This is why the issue would usually not arise when using the UI normally to add points one at a time, but instead occurs when pasting a route URL where multiple API calls now suddenly have to be executed all at once.

The nature of the issue means it is a little hard to reliably reproduce, but you should be able to encounter the issue when pasting URLs for routes with a good few waypoints (and maybe a couple refreshes as this behaviour is not always consistent).

My proposed change is to replace the previous logic for executing the Valhalla API call (using the `permaLast` variable) with a new solution that only executes once `pendingGeocodes` (the number of geocode results yet to be returned from the Nominatim API) is 0.

## 📄 Note to reviewers

I have experienced consistent correct behaviour in my testing of this new solution, though as this change concerns a fairly critical part of the application, I would encourage others to pull this branch and test it out for themselves, just to be sure!

## 📷 Screenshots

**Before:**

https://valhalla.openstreetmap.de/directions?profile=car&wps=6.0972029%2C52.2093817%2C7.0408738%2C52.3124012%2C7.0679909%2C52.3202517%2C12.7509051%2C52.9060194%2C12.8532636%2C52.7535156

When accessing the above URL, some points will sometimes not be included in the route. Here is a particularly bad example I was able to reproduce where only the start and end points (1 and 5) were included in the route and the rest were ignored:

<img width="1919" height="1017" alt="image4" src="https://github.com/user-attachments/assets/fbad4fa0-4e38-42e0-9830-8f78380b0999" />
<img width="1919" height="1016" alt="image5" src="https://github.com/user-attachments/assets/be10722f-e300-495b-9d32-958148a52820" />
<img width="1919" height="1019" alt="image6" src="https://github.com/user-attachments/assets/e2cdf1e7-6310-4f88-81d4-9299ec32c960" />

**After:**

Fixed, accessing the URL now consistently results in all points being included in the route:

<img width="1919" height="1017" alt="image7" src="https://github.com/user-attachments/assets/8dcf29f2-ab9c-4809-8d4b-fea5a8a180e4" />
<img width="1919" height="1018" alt="image8" src="https://github.com/user-attachments/assets/d58a6bbe-b6ae-42c9-8b1d-90149d08890f" />
<img width="1919" height="1016" alt="image9" src="https://github.com/user-attachments/assets/c6eb2fb5-3d27-4112-b48c-509c8c4abae8" />
