### PR TITLE
urgent: revert parse int to fix a bug where waypoints are not a number

### DIFF
--- a/src/actions/directionsActions.ts
+++ b/src/actions/directionsActions.ts
@@ -353,11 +353,7 @@ const processGeocodeResponse =
     permaLast?: boolean
   ): ThunkResult =>
   (dispatch) => {
-    if (!lngLat) {
-      lngLat = [parseFloat(data.lon), parseFloat(data.lat)];
-    }
-
-    const addresses = parseGeocodeResponse(data, lngLat);
+    const addresses = parseGeocodeResponse(data, lngLat!);
     // if no address can be found
     if (addresses.length === 0) {
       dispatch(

--- a/src/actions/isochronesActions.ts
+++ b/src/actions/isochronesActions.ts
@@ -240,11 +240,7 @@ const processGeocodeResponse =
     lngLat?: [number, number]
   ): ThunkResult =>
   (dispatch) => {
-    if (!lngLat) {
-      lngLat = [parseFloat(data.lon), parseFloat(data.lat)];
-    }
-
-    const addresses = parseGeocodeResponse(data, lngLat);
+    const addresses = parseGeocodeResponse(data, lngLat!);
     // if no address can be found
     if (addresses.length === 0) {
       dispatch(


### PR DESCRIPTION
while migrating to typescript, I added parseInt's to handle undefined longitude latitude cases but apparently, they are always undefined at first. because of that, whenever user search something from input and select a location; we are throwing an error.

this fixes that search problem.