### PR TITLE
chore: add playwright dirs to ignores/excludes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@ node_modules
 
 # testing
 coverage
+playwright-report
+test-results
 
 # production
 build

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,8 @@ export default defineConfig(
       'build',
       'dist',
       'coverage',
+      'playwright-report',
+      'test-results',
       '**/*.css',
       '**/*.scss',
       '**/*.less',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,11 @@
     }
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.js", "vite.config.ts"],
-  "exclude": ["node_modules", "coverage", "build"]
+  "exclude": [
+    "node_modules",
+    "coverage",
+    "build",
+    "playwright-report",
+    "test-results"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,13 +2,22 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    exclude: ['node_modules', 'build', 'dist', 'coverage', 'e2e'],
+    exclude: [
+      'node_modules',
+      'build',
+      'dist',
+      'coverage',
+      'e2e',
+      'playwright-report',
+      'test-results',
+    ],
     globals: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       exclude: [
         'node_modules/',
+        'playwright-report/',
         'src/test-utils.ts',
         '**/*.d.ts',
         '**/*.config.*',


### PR DESCRIPTION
## 🛠️ Fixes Issue

Very minor fix, just noticed some output dirs generated by Playwright weren't included in a few places where we have ignores/excludes. Best to exclude them for linting, coverage, etc.